### PR TITLE
Updated `NoteListViewModel` to observe database changes

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -80,6 +80,8 @@ kotlin {
             implementation(libs.androidx.core.splashscreen)
             implementation(libs.androidx.work.runtime)
             implementation(libs.koin.androidx.workmanager)
+            implementation("com.facebook.stetho:stetho:1.6.0")
+            implementation("com.facebook.stetho:stetho-okhttp3:1.6.0")
         }
 
         iosMain.dependencies {

--- a/composeApp/src/androidMain/kotlin/me/androidbox/NoteMarkApplication.kt
+++ b/composeApp/src/androidMain/kotlin/me/androidbox/NoteMarkApplication.kt
@@ -1,6 +1,7 @@
 package me.androidbox
 
 import android.app.Application
+import com.facebook.stetho.Stetho
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.logger.Level
@@ -9,6 +10,7 @@ class NoteMarkApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        Stetho.initializeWithDefaults(this@NoteMarkApplication)
 
         initializeKoin(
             config = {

--- a/composeApp/src/commonMain/kotlin/me/androidbox/notes/data/repository/NotesRepositoryImp.kt
+++ b/composeApp/src/commonMain/kotlin/me/androidbox/notes/data/repository/NotesRepositoryImp.kt
@@ -223,6 +223,7 @@ class NotesRepositoryImp(
                     .map { noteItem -> noteItem.toNoteItemEntity() }
 
                 applicationScope.async {
+                    // QUESTION: Is it ok to clear all notes before fetching new one each time
                     notesLocalDataSource.nukeAllNotes()
                     notesLocalDataSource.saveAllNotes(notes)
                     Left(Unit)

--- a/composeApp/src/commonMain/kotlin/me/androidbox/notes/domain/usecases/imp/FetchNotesUseCaseImp.kt
+++ b/composeApp/src/commonMain/kotlin/me/androidbox/notes/domain/usecases/imp/FetchNotesUseCaseImp.kt
@@ -1,16 +1,14 @@
 package me.androidbox.notes.domain.usecases.imp
 
 import kotlinx.coroutines.flow.Flow
-import me.androidbox.core.models.DataError
 import me.androidbox.notes.domain.NotesRepository
 import me.androidbox.notes.domain.model.NoteItem
 import me.androidbox.notes.domain.usecases.FetchNotesUseCase
-import net.orandja.either.Either
 
 class FetchNotesUseCaseImp(
     private val notesRepository: NotesRepository
 ) : FetchNotesUseCase {
     override suspend fun execute(): Flow<List<NoteItem>> {
-        return notesRepository.fetchNotes(0, 0)
+        return notesRepository.fetchNotes(-1, 0)
     }
 }


### PR DESCRIPTION
…tho for debugging.

Key changes:
- Modified `NoteListViewModel` to observe note changes directly from the database.
- Integrated Stetho for Android debugging by adding dependencies and initializing it in the `NoteMarkApplication`.
- Changed `FetchNotesUseCaseImp` to fetch all notes by passing -1 as a parameter.
- Updated `NotesRepositoryImp` to clear all local notes before saving new ones during `fetchAllNotes`.