### PR TITLE
Updated user's sync interval and last sync timestamp upon successful …

### DIFF
--- a/composeApp/src/commonMain/kotlin/me/androidbox/settings/presentation/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/me/androidbox/settings/presentation/SettingsViewModel.kt
@@ -153,15 +153,22 @@ class SettingsViewModel(
 
                     notesRepository.syncPendingNotes()
 
+                    userRepository.saveUser(
+                        User(
+                            userName = noteMarkPreferences.getUserName()!!,
+                            syncInterval = state.value.selectedSyncInterval,
+                            syncTimeStamp = Clock.System.now().toEpochMilliseconds()
+                        )
+                    )
+
                     _state.update { uiState ->
                         uiState.copy(
                             isLoadingSync = false,
-                            lastSyncTime = "Just now" /** Should calculate the time difference from the last sync, just a hack for submission */
+                            lastSyncTime = "Just now"
                         )
                     }
                 }
             }
-
         }
     }
 }


### PR DESCRIPTION
…manual sync.

Key changes:
- In `SettingsViewModel`, after a successful manual sync:
    - Saved the selected sync interval from the UI state to the user's preferences.
    - Saved the current timestamp as the last sync time to the user's preferences.
    - Updated the UI to display "Just now" as the last sync time.